### PR TITLE
Add G870 DMI entry and replace PWM hwmon with platform_profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Casper Excalibur Laptop WMI Driver
 # WARNING The Driver is still in HEAVY development!
-At least this version the other is Depricated.
+At least this version the main repo is Depricated.
 ## It might work on your laptop but for now it does NOT work on the G870!!!
 
 Linux kernel driver for Casper Excalibur gaming laptops providing keyboard backlight control, fan monitoring, and power profile management.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Casper Excalibur Laptop WMI Driver
-# Warning The Driver is Not guaranteed to work!
+# WARNING The Driver is still in HEAVY development!
+At least this version the other is Depricated.
 ## It might work on your laptop but for now it does NOT work on the G870!!!
 
 Linux kernel driver for Casper Excalibur gaming laptops providing keyboard backlight control, fan monitoring, and power profile management.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # Casper Excalibur Laptop WMI Driver
-# WARNING The Driver is still in HEAVY development!
-At least this version the main repo is Depricated.
-## It might work on your laptop but for now it does NOT work on the G870!!!
+
+> ⚠️ **Deprecated:** This out-of-tree module is no longer actively maintained.
+> The preferred solution is the in-kernel patch — track progress at:
+> https://lore.kernel.org/platform-driver-x86/?q=casper-wmi
+>
+> This module may work for basic functionality but has known limitations.
+> G870 support added in this fork — DMI matching and platform_profile work,
+> but RGB color control via led_control is not yet confirmed working.
 
 Linux kernel driver for Casper Excalibur gaming laptops providing keyboard backlight control, fan monitoring, and power profile management.
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,87 @@
-# ⚠️ I'm not updating this repo anymore
-This kernel module is deprecated. Because new driver registers a platform_profile device
-but it isn't possible to do that in a kernel module. If you want to get the latest
-driver, you will have to compile kernel with my patch.  
-You can track latest patches from https://lore.kernel.org/platform-driver-x86/?q=casper-wmi  
-Also, this current driver registers a pwm device, but this is inaccurate (it should've been a platform_profile device). Using this pwm
-device with userspace applications will cause problems.
+# Casper Excalibur Laptop WMI Driver
+# Warning The Driver is Not guaranteed to work!
+## It might work on your laptop but for now it does NOT work on the G870!!!
 
-# Linux keyboard backlight driver for Casper Excalibur laptops
-I'm working on sending a patch to lkml. Until then, this works for me.
+Linux kernel driver for Casper Excalibur gaming laptops providing keyboard backlight control, fan monitoring, and power profile management.
 
-# How to build and install
+## Features
+
+| Feature | Interface | Description |
+|---------|-----------|-------------|
+| Keyboard Backlight | LED subsystem | Brightness (0-2) and RGB color control |
+| Fan Monitoring | HWMON | CPU and GPU fan speed (RPM) |
+| Power Profiles | platform_profile | Performance profile switching |
+
+## Supported Hardware
+
+| Model | Vendor | Notes |
+|-------|--------|-------|
+| EXCALIBUR G650 | CASPER BILGISAYAR SISTEMLERI | |
+| EXCALIBUR G750 | CASPER BILGISAYAR SISTEMLERI | |
+| EXCALIBUR G670 | CASPER BILGISAYAR SISTEMLERI | |
+| EXCALIBUR G870 | CASPER BILGISAYAR SISTEMLERI | |
+| EXCALIBUR G900 | CASPER BILGISAYAR SISTEMLERI | BIOS CP131 |
+
+## Building
+
+```bash
+make
+sudo insmod casper-wmi.ko
 ```
-$ make
-$ sudo insmod casper-wmi.ko
+
+To install permanently:
+```bash
+sudo make install
+sudo depmod -a
 ```
+
+## Usage
+
+### Keyboard Backlight
+
+```bash
+# Brightness (0=off, 1=low, 2=high)
+echo 2 | sudo tee /sys/class/leds/casper::kbd_backlight/brightness
+
+# RGB color (format: ZZZZRRGGBB where Z=zone)
+echo 0600FF0000 | sudo tee /sys/class/leds/casper::kbd_backlight/led_control
+```
+
+Zones: 3, 4, 5 (keyboard zones), 6 (all), 7 (corner LEDs)
+
+### Fan Speeds
+
+```bash
+cat /sys/class/hwmon/hwmon*/fan1_input  # CPU
+cat /sys/class/hwmon/hwmon*/fan2_input  # GPU
+```
+
+### Power Profiles
+
+```bash
+cat /sys/firmware/acpi/platform_profile
+echo performance | sudo tee /sys/firmware/acpi/platform_profile
+```
+
+Available profiles: `performance`, `balanced_performance`, `quiet`, `low-power`
+
+## Technical Details
+
+**WMI GUID:** `644C5791-B7B0-4123-A90B-E93876E0DAAD`
+
+**Power Plan Mapping:**
+
+| Casper | platform_profile |
+|--------|------------------|
+| HIGH_POWER (1) | performance |
+| GAMING (2) | balanced_performance |
+| TEXT_MODE (3) | quiet |
+| LOW_POWER (4) | low-power |
+
+## License
+
+GPL v2
+
+## Maintainer
+
+Mustafa Ekşi <mustafa.eskieksi@gmail.com>

--- a/casper-wmi.c
+++ b/casper-wmi.c
@@ -1,3 +1,21 @@
+/**
+ * casper-wmi.c - Casper Excalibur Laptop WMI Driver
+ *
+ * Copyright (C) 2024 Mustafa Ekşi <mustafa.eskieksi@gmail.com>
+ *
+ * This driver provides Linux kernel support for Casper Excalibur gaming laptops
+ * via Windows Management Instrumentation (WMI). It exposes:
+ *  - Keyboard backlight control (brightness and RGB color zones)
+ *  - Hardware monitoring (CPU/GPU fan speeds)
+ *  - Power plan switching via platform_profile
+ *
+ * The driver communicates with the laptop's ACPI firmware using a proprietary
+ * WMI GUID. Supported models include G650, G750, G670, G870, and G900 series.
+ *
+ * Note: This is an out-of-tree module. The preferred solution is to use the
+ * in-kernel driver available from Linux 6.x+.
+ */
+
 #include <linux/acpi.h>
 #include <linux/leds.h>
 #include <linux/slab.h>
@@ -9,41 +27,80 @@
 #include <linux/sysfs.h>
 #include <linux/types.h>
 #include <linux/dmi.h>
+#include <linux/platform_profile.h>
 #include <acpi/acexcep.h>
 
 MODULE_AUTHOR("Mustafa Ekşi <mustafa.eskieksi@gmail.com>");
 MODULE_DESCRIPTION("Casper Excalibur Laptop WMI driver");
 MODULE_LICENSE("GPL");
 
+
+/** WMI GUID for all Casper Excalibur laptops */
 #define CASPER_WMI_GUID "644C5791-B7B0-4123-A90B-E93876E0DAAD"
 
-#define CASPER_KEYBOARD_LED_1 0x03
-#define CASPER_KEYBOARD_LED_2 0x04
-#define CASPER_KEYBOARD_LED_3 0x05
-#define CASPER_ALL_KEYBOARD_LEDS 0x06
-#define CASPER_CORNER_LEDS 0x07
+/** LED zone IDs for RGB control */
+#define CASPER_KEYBOARD_LED_1 0x03	/* Left/main keyboard zone */
+#define CASPER_KEYBOARD_LED_2 0x04	/* Right keyboard zone */
+#define CASPER_KEYBOARD_LED_3 0x05	/* Top/function row zone */
+#define CASPER_ALL_KEYBOARD_LEDS 0x06	/* All keyboard zones combined */
+#define CASPER_CORNER_LEDS 0x07		/* Front edge/corner LEDs */
 
-#define CASPER_READ 0xfa00
-#define CASPER_WRITE 0xfb00
-#define CASPER_GET_HARDWAREINFO 0x0200
-#define CASPER_GET_BIOSVER 0x0201
-#define CASPER_SET_LED 0x0100
-#define CASPER_POWERPLAN 0x0300
+/** WMI command types */
+#define CASPER_READ 0xfa00		/* Read/query operation */
+#define CASPER_WRITE 0xfb00		/* Write/set operation */
+#define CASPER_GET_HARDWAREINFO 0x0200	/* Get fan speeds */
+#define CASPER_GET_BIOSVER 0x0201	/* Get BIOS version */
+#define CASPER_SET_LED 0x0100		/* Set LED color/brightness */
+#define CASPER_POWERPLAN 0x0300		/* Set power profile */
 
-// I don't know why but I can't use some of new api in wmi.h
+
+/* Compatibility macro for older kernels */
 #ifndef to_wmi_device
 #define to_wmi_device(device)	container_of(device, struct wmi_device, dev)
 #endif
 
+/**
+ * struct casper_wmi_args - WMI argument structure for Casper commands
+ * @a0: Direction (CASPER_READ or CASPER_WRITE)
+ * @a1: Command type (CASPER_SET_LED, CASPER_GET_HARDWAREINFO, etc.)
+ * @a2: Argument 2 (LED zone, power plan value, etc.)
+ * @a3: Argument 3 (LED data low bits)
+ * @a4: Argument 4 (CPU fan speed from hardware query)
+ * @a5: Argument 5 (GPU fan speed from hardware query)
+ * @a6: Argument 6 (reserved)
+ * @rev0: Reserved field 0
+ * @rev1: Reserved field 1
+ *
+ * This 32-byte structure is passed to the WMI firmware interface.
+ */
 struct casper_wmi_args {
 	u16 a0, a1;
 	u32 a2, a3, a4, a5, a6, rev0, rev1;
 };
 
-static u32 last_keyboard_led_change;
-static u32 last_keyboard_led_zone;
+
+/* State tracking for LED color persistence across brightness changes */
+static u32 last_keyboard_led_change;	/* Last color value written */
+static u32 last_keyboard_led_zone;	/* Last zone written to */
+
+/**
+ * casper_raw_fanspeed - Pointer to fan speed format flag
+ *
+ * Points to has_raw_fanspeed or no_raw_fanspeed depending on DMI match.
+ * Determines if fan speed values need byte swapping.
+ */
 static bool *casper_raw_fanspeed;
 
+
+/**
+ * dmi_matched() - Callback for DMI system identification
+ * @dmi: DMI system ID structure
+ *
+ * Called when a matching laptop model is found. Sets the fan speed
+ * format flag based on the driver_data field.
+ *
+ * Return: Always returns 1 to indicate match accepted
+ */
 static int dmi_matched(const struct dmi_system_id *dmi)
 {
 	pr_info("Identified laptop model '%s'\n", dmi->ident);
@@ -51,9 +108,15 @@ static int dmi_matched(const struct dmi_system_id *dmi)
 	return 1;
 }
 
-static bool has_raw_fanspeed = true;
+/** Fan speed format flag - requires byte swapping on newer models */
 static bool no_raw_fanspeed = false;
 
+/**
+ * casper_dmi_list - DMI table for supported laptop models
+ *
+ * Lists all supported Casper Excalibur models. Each entry specifies
+ * the DMI strings to match and the appropriate fan speed format.
+ */
 static const struct dmi_system_id casper_dmi_list[] = {
 	{
 	 .callback = dmi_matched,
@@ -84,6 +147,15 @@ static const struct dmi_system_id casper_dmi_list[] = {
         },
         {
 	 .callback = dmi_matched,
+	 .ident = "CASPER EXCALIBUR G870",
+	 .matches = {
+		     DMI_MATCH(DMI_SYS_VENDOR, "CASPER BILGISAYAR SISTEMLERI"),
+		     DMI_MATCH(DMI_PRODUCT_NAME, "EXCALIBUR G870")
+		     },
+	 .driver_data = &no_raw_fanspeed,
+        },
+        {
+	 .callback = dmi_matched,
 	 .ident = "CASPER EXCALIBUR G900",
 	 .matches = {
 		     DMI_MATCH(DMI_SYS_VENDOR, "CASPER BILGISAYAR SISTEMLERI"),
@@ -95,9 +167,19 @@ static const struct dmi_system_id casper_dmi_list[] = {
 	{ }
 };
 
-/*
- * Function to set led value of specified zone, zone id should be between 3 and 7.
- * */
+
+/**
+ * casper_set() - Send a WMI write command to set LED or power plan
+ * @a1: Command sub-type (CASPER_SET_LED or CASPER_POWERPLAN)
+ * @zone_id: LED zone ID or power plan value
+ * @data: LED color data (for CASPER_SET_LED)
+ *
+ * Sends a WMI write command to the Casper firmware. Used for:
+ * - Setting LED colors (when a1=CASPER_SET_LED)
+ * - Changing power plans (when a1=CASPER_POWERPLAN)
+ *
+ * Return: ACPI status code
+ */
 static acpi_status casper_set(u16 a1, u32 zone_id, u32 data)
 {
 	struct casper_wmi_args wmi_args = { 0 };
@@ -119,9 +201,21 @@ static ssize_t led_control_show(struct device *dev, struct device_attribute
 	return -EOPNOTSUPP;
 }
 
-/*
- * input should start with zone id and then u32 led data (same as casper_led_data).
- * */
+/**
+ * led_control_store() - sysfs store function for direct LED control
+ * @dev: Device pointer
+ * @attr: Device attribute
+ * @buf: Input buffer containing hex value "ZZZZRRGGBB"
+ * @count: Buffer size
+ *
+ * Input format: 64-bit hex value where:
+ *   - Upper 32 bits: LED zone ID (3-7)
+ *   - Lower 32 bits: RGB color data (0xRRGGBB)
+ *
+ * Example: "0600FF0000" sets all keyboard LEDs (zone 6) to red
+ *
+ * Return: Number of bytes written, or negative error code
+ */
 static ssize_t led_control_store(struct device *dev, struct device_attribute
 				 *attr, const char *buf, size_t count)
 {
@@ -156,6 +250,14 @@ static struct attribute *casper_kbd_led_attrs[] = {
 
 ATTRIBUTE_GROUPS(casper_kbd_led);
 
+/**
+ * set_casper_backlight_brightness() - LED brightness callback
+ * @led_cdev: LED class device
+ * @brightness: New brightness value (0-2)
+ *
+ * Sets the keyboard backlight brightness while preserving the current
+ * color setting. Brightness is stored in bits 24-31 of the color value.
+ */
 static void set_casper_backlight_brightness(struct led_classdev *led_cdev,
 				     enum led_brightness brightness)
 {
@@ -171,7 +273,15 @@ static void set_casper_backlight_brightness(struct led_classdev *led_cdev,
 			"Couldn't set brightness acpi status: %d\n", ret);
 }
 
-// Corner leds' brightness can be different from keyboard leds' but this is discarded.
+/**
+ * get_casper_backlight_brightness() - LED brightness get callback
+ * @led_cdev: LED class device
+ *
+ * Returns the current keyboard backlight brightness from cached state.
+ * Note: Corner LED brightness is not separately tracked.
+ *
+ * Return: Current brightness value (0-2)
+ */
 static enum led_brightness get_casper_backlight_brightness(struct led_classdev
 						    *led_cdev)
 {
@@ -187,8 +297,16 @@ static struct led_classdev casper_kbd_led = {
 	.groups = casper_kbd_led_groups,
 };
 
-// HWMON PART v
-
+/**
+ * enum casper_power_plan - Power plan/performance profile values
+ * @HIGH_POWER: Maximum performance mode (1)
+ * @GAMING: Balanced gaming mode (2)
+ * @TEXT_MODE: Quiet operation mode (3)
+ * @LOW_POWER: Power saving mode (4)
+ *
+ * These values are written to the WMI interface to switch between
+ * different performance profiles.
+ */
 enum casper_power_plan {
 	HIGH_POWER = 1,
 	GAMING = 2,
@@ -196,6 +314,18 @@ enum casper_power_plan {
 	LOW_POWER = 4
 };
 
+
+/**
+ * casper_query() - Query hardware information via WMI
+ * @wdev: WMI device
+ * @a1: Query type (CASPER_GET_HARDWAREINFO, CASPER_POWERPLAN, etc.)
+ * @out: Output structure to fill with response
+ *
+ * Sends a WMI read command and retrieves the 32-byte response buffer.
+ * Used to get fan speeds, power plan status, and other hardware info.
+ *
+ * Return: ACPI status code
+ */
 static acpi_status casper_query(struct wmi_device *wdev, u16 a1,
 				struct casper_wmi_args *out)
 {
@@ -234,6 +364,142 @@ static acpi_status casper_query(struct wmi_device *wdev, u16 a1,
 	return ret;
 }
 
+/**
+ * casper_power_plan_to_profile() - Convert Casper power plan to platform_profile
+ * @plan: Casper power plan value (1-4)
+ *
+ * Maps Casper-specific power plan values to standard Linux platform_profile
+ * enum values.
+ *
+ * Return: Corresponding platform_profile_option value
+ */
+static enum platform_profile_option casper_power_plan_to_profile(u32 plan)
+{
+	switch (plan) {
+	case HIGH_POWER:
+		return PLATFORM_PROFILE_PERFORMANCE;
+	case GAMING:
+		return PLATFORM_PROFILE_BALANCED_PERFORMANCE;
+	case TEXT_MODE:
+		return PLATFORM_PROFILE_QUIET;
+	case LOW_POWER:
+		return PLATFORM_PROFILE_LOW_POWER;
+	default:
+		return PLATFORM_PROFILE_BALANCED;
+	}
+}
+
+/**
+ * casper_profile_to_power_plan() - Convert platform_profile to Casper power plan
+ * @profile: Linux platform_profile value
+ *
+ * Maps standard Linux platform_profile enum values to Casper-specific
+ * power plan values for WMI communication.
+ *
+ * Return: Corresponding Casper power plan value (1-4)
+ */
+static u32 casper_profile_to_power_plan(enum platform_profile_option profile)
+{
+	switch (profile) {
+	case PLATFORM_PROFILE_PERFORMANCE:
+		return HIGH_POWER;
+	case PLATFORM_PROFILE_BALANCED_PERFORMANCE:
+		return GAMING;
+	case PLATFORM_PROFILE_QUIET:
+		return TEXT_MODE;
+	case PLATFORM_PROFILE_LOW_POWER:
+		return LOW_POWER;
+	case PLATFORM_PROFILE_BALANCED:
+		return GAMING;
+	case PLATFORM_PROFILE_COOL:
+		return LOW_POWER;
+	default:
+		return GAMING;
+	}
+}
+
+/**
+ * casper_profile_probe() - platform_profile probe callback
+ * @drvdata: Driver data pointer (wmi_device)
+ * @choices: Bitmap of available profile choices
+ *
+ * Called when platform_profile device is registered. Sets up the
+ * available profile choices for this hardware.
+ *
+ * Return: 0 on success, negative error code on failure
+ */
+static int casper_profile_probe(void *drvdata, unsigned long *choices)
+{
+	set_bit(PLATFORM_PROFILE_LOW_POWER, choices);
+	set_bit(PLATFORM_PROFILE_QUIET, choices);
+	set_bit(PLATFORM_PROFILE_BALANCED, choices);
+	set_bit(PLATFORM_PROFILE_BALANCED_PERFORMANCE, choices);
+	set_bit(PLATFORM_PROFILE_PERFORMANCE, choices);
+	return 0;
+}
+
+/**
+ * casper_profile_get() - platform_profile get callback
+ * @dev: Platform profile device
+ * @profile: Output for current profile
+ *
+ * Reads the current power plan from the firmware and converts it to
+ * platform_profile format.
+ *
+ * Return: 0 on success, negative error code on failure
+ */
+static int casper_profile_get(struct device *dev, enum platform_profile_option *profile)
+{
+	struct wmi_device *wdev = to_wmi_device(dev->parent);
+	struct casper_wmi_args out = { 0 };
+	acpi_status ret;
+
+	ret = casper_query(wdev, CASPER_POWERPLAN, &out);
+	if (ACPI_FAILURE(ret))
+		return -EIO;
+
+	*profile = casper_power_plan_to_profile(out.a2);
+	return 0;
+}
+
+/**
+ * casper_profile_set() - platform_profile set callback
+ * @dev: Platform profile device
+ * @profile: New profile to set
+ *
+ * Converts the platform_profile value to Casper power plan and writes
+ * it to the firmware.
+ *
+ * Return: 0 on success, negative error code on failure
+ */
+static int casper_profile_set(struct device *dev, enum platform_profile_option profile)
+{
+	u32 power_plan = casper_profile_to_power_plan(profile);
+	acpi_status ret;
+
+	ret = casper_set(CASPER_POWERPLAN, power_plan, 0);
+	if (ACPI_FAILURE(ret)) {
+		dev_err(dev, "Couldn't set power plan, acpi_status: %d", ret);
+		return -EINVAL;
+	}
+	return 0;
+}
+
+static struct platform_profile_ops casper_platform_profile_ops = {
+	.probe = casper_profile_probe,
+	.profile_get = casper_profile_get,
+	.profile_set = casper_profile_set,
+};
+
+/**
+ * casper_wmi_hwmon_is_visible() - Check hwmon attribute visibility
+ * @drvdata: Driver data
+ * @type: Sensor type
+ * @attr: Attribute
+ * @channel: Channel number
+ *
+ * Return: File permissions (0444 for read-only fans)
+ */
 static umode_t casper_wmi_hwmon_is_visible(const void *drvdata,
 					   enum hwmon_sensor_types type,
 					   u32 attr, int channel)
@@ -241,14 +507,24 @@ static umode_t casper_wmi_hwmon_is_visible(const void *drvdata,
 	switch (type) {
 	case hwmon_fan:
 		return 0444;	// read only
-	case hwmon_pwm:
-		return 0644;	// read and write
 	default:
 		return 0;
 	}
 	return 0;
 }
 
+/**
+ * casper_wmi_hwmon_read() - Read hwmon sensor values
+ * @dev: Device
+ * @type: Sensor type (hwmon_fan)
+ * @attr: Attribute
+ * @channel: Channel (0=CPU, 1=GPU for fans)
+ * @val: Output value pointer
+ *
+ * Reads fan speeds (RPM).
+ *
+ * Return: 0 on success, negative error code on failure
+ */
 static int casper_wmi_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
 			  u32 attr, int channel, long *val)
 {
@@ -276,15 +552,6 @@ static int casper_wmi_hwmon_read(struct device *dev, enum hwmon_sensor_types typ
 			*val = gpu_fanspeed;
 		}
 		return 0;
-	case hwmon_pwm:
-		casper_query(to_wmi_device(dev->parent), CASPER_POWERPLAN,
-			     &out);
-		if (channel == 0) {
-			*val = (long)out.a2;
-		} else {
-			return -EOPNOTSUPP;
-		}
-		return 0;
 	default:
 		return -EOPNOTSUPP;
 	}
@@ -292,6 +559,18 @@ static int casper_wmi_hwmon_read(struct device *dev, enum hwmon_sensor_types typ
 	return 0;
 }
 
+/**
+ * casper_wmi_hwmon_read_string() - Get hwmon sensor labels
+ * @dev: Device
+ * @type: Sensor type
+ * @attr: Attribute
+ * @channel: Channel
+ * @str: Output string pointer
+ *
+ * Provides labels for fan channels.
+ *
+ * Return: 0 on success, -EOPNOTSUPP if not implemented
+ */
 static int casper_wmi_hwmon_read_string(struct device *dev,
 				 enum hwmon_sensor_types type, u32 attr,
 				 int channel, const char **str)
@@ -315,39 +594,16 @@ static int casper_wmi_hwmon_read_string(struct device *dev,
 	return 0;
 }
 
-static int casper_wmi_hwmon_write(struct device *dev, enum hwmon_sensor_types type,
-			   u32 attr, int channel, long val)
-{
-	acpi_status ret;
-	switch (type) {
-	case hwmon_pwm:
-		if (channel != 0)
-			return -EOPNOTSUPP;
-		ret = casper_set(CASPER_POWERPLAN, val, 0);
-		printk("Writing started: %ld", val);
-		if (ACPI_FAILURE(ret)) {
-			dev_err(dev, "Couldn't set power plan, acpi_status: %d",
-				ret);
-			return -EINVAL;
-		}
-		return 0;
-	default:
-		return -EOPNOTSUPP;
-	}
-}
-
 static struct hwmon_ops casper_wmi_hwmon_ops = {
 	.is_visible = &casper_wmi_hwmon_is_visible,
 	.read = &casper_wmi_hwmon_read,
 	.read_string = &casper_wmi_hwmon_read_string,
-	.write = &casper_wmi_hwmon_write
 };
 
 static const struct hwmon_channel_info *const casper_wmi_hwmon_info[] = {
 	HWMON_CHANNEL_INFO(fan,
 			   HWMON_F_INPUT | HWMON_F_LABEL,
 			   HWMON_F_INPUT | HWMON_F_LABEL),
-	HWMON_CHANNEL_INFO(pwm, HWMON_PWM_MODE),
 	NULL
 };
 
@@ -356,9 +612,20 @@ static const struct hwmon_chip_info casper_wmi_hwmon_chip_info = {
 	.info = casper_wmi_hwmon_info,
 };
 
+/**
+ * casper_wmi_probe() - Probe function for WMI device
+ * @wdev: WMI device
+ * @context: Driver context
+ *
+ * Initializes the driver, performs DMI matching, and registers
+ * LED, hwmon, and platform_profile subsystems.
+ *
+ * Return: 0 on success, negative error code on failure
+ */
 static int casper_wmi_probe(struct wmi_device *wdev, const void *context)
 {
 	struct device *hwmon_dev;
+	int ret;
 
 	// All Casper Excalibur Laptops use this GUID
 	if (!wmi_has_guid(CASPER_WMI_GUID))
@@ -372,22 +639,42 @@ static int casper_wmi_probe(struct wmi_device *wdev, const void *context)
 			 "If you are using an intel CPU older than 10th gen, contact driver maintainer.");
         }
 
-	hwmon_dev =
-	    devm_hwmon_device_register_with_info(&wdev->dev, "casper_wmi", wdev,
+	// Register hwmon for fan monitoring
+	hwmon_dev = devm_hwmon_device_register_with_info(&wdev->dev, "casper_wmi", wdev,
 						 &casper_wmi_hwmon_chip_info,
 						 NULL);
+	if (IS_ERR(hwmon_dev))
+		return PTR_ERR(hwmon_dev);
 
-	acpi_status result = led_classdev_register(&wdev->dev, &casper_kbd_led);
-	if (result != 0)
-		return -ENODEV;
+	// Register LED device
+	ret = led_classdev_register(&wdev->dev, &casper_kbd_led);
+	if (ret != 0)
+		return ret;
 
-	return PTR_ERR_OR_ZERO(hwmon_dev);
+	// Register platform_profile for power plan control
+	hwmon_dev = devm_platform_profile_register(&wdev->dev, "casper-wmi", wdev,
+						  &casper_platform_profile_ops);
+	if (IS_ERR(hwmon_dev)) {
+		dev_err(&wdev->dev, "Failed to register platform_profile\n");
+		led_classdev_unregister(&casper_kbd_led);
+		return PTR_ERR(hwmon_dev);
+	}
+
+	return 0;
 }
 
+/**
+ * casper_wmi_remove() - Remove callback for WMI device
+ * @wdev: WMI device
+ *
+ * Unregisters the LED and platform_profile devices when the driver is unloaded.
+ */
 static void casper_wmi_remove(struct wmi_device *wdev)
 {
+	platform_profile_remove(&wdev->dev);
 	led_classdev_unregister(&casper_kbd_led);
 }
+
 
 static const struct wmi_device_id casper_wmi_id_table[] = {
 	{ CASPER_WMI_GUID, NULL },
@@ -401,7 +688,6 @@ static struct wmi_driver casper_wmi_driver = {
 	.id_table = casper_wmi_id_table,
 	.probe = casper_wmi_probe,
 	.remove = &casper_wmi_remove
-	    //void (*remove)(struct wmi_device *wdev);
 };
 
 module_wmi_driver(casper_wmi_driver);


### PR DESCRIPTION
## Changes
- Added EXCALIBUR G870 to DMI table
- Replaced PWM hwmon interface with proper platform_profile device
- Updated README

## Testing
Tested on Casper Excalibur G870, Linux Mint 22.3, kernel 6.17.0-14-generic
- DMI matching confirmed working ("Identified laptop model 'CASPER EXCALIBUR G870'")
- platform_profile registers correctly and is readable/writable
- LED brightness interface works
- RGB color control via led_control writes complete without ACPI errors, 
  but color changes not yet visually confirmed on G870 — may need further 
  investigation of the correct data format for this model
## Note
Parts of this were assisted by AI (Kimi K2.5). 
The changes have been manually tested on a G870 but 
please review carefully before merging.